### PR TITLE
Optional converti mode

### DIFF
--- a/miraie_ac/device.py
+++ b/miraie_ac/device.py
@@ -152,7 +152,7 @@ class Device:
             else PresetMode.ECO
             if status["acem"] == "on"
             else PresetMode.NONE,
-            converti_mode=ConvertiMode(status["cnv"]),
+            converti_mode=ConvertiMode(status.get("cnv", 0)),
         )
 
         self.set_status(status_obj)

--- a/miraie_ac/hub.py
+++ b/miraie_ac/hub.py
@@ -214,7 +214,7 @@ class MirAIeHub:
                     else PresetMode.ECO
                     if status["acem"] == "on"
                     else PresetMode.NONE,
-                    converti_mode=ConvertiMode(status["cnv"]),
+                    converti_mode=ConvertiMode(status.get("cnv", 0)),
                 )
 
             device.set_status(status_obj)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "miraie-ac"
-version = "1.0.6"
+version = "1.0.7"
 description = "MirAIe-AC API for Python"
 authors = ["Raj Kishore <40551183+rkzofficial@users.noreply.github.com>", "Ali Jafri <deCodeIt@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
Devices which don't support converti mode were failing to initialize the integration. This patch fixes the same by making convert mode optional.