### PR TITLE
Add Not-supported enum for Converti

### DIFF
--- a/miraie_ac/enums.py
+++ b/miraie_ac/enums.py
@@ -63,4 +63,6 @@ class ConvertiMode(Enum):
     C70 = 70
     C55 = 55
     C40 = 40
+    # Not supported
+    NS = 1
     OFF = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "miraie-ac"
-version = "1.0.7"
+version = "1.0.8"
 description = "MirAIe-AC API for Python"
 authors = ["Raj Kishore <40551183+rkzofficial@users.noreply.github.com>", "Ali Jafri <deCodeIt@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
For ACs which do not support Non-Convertible mode, the converti value was coming out to be 1 which was absent from our codebase. The same has been added in this patch.