### PR TITLE
fix: handle empty devices case + fix typo

### DIFF
--- a/miraie_ac/hub.py
+++ b/miraie_ac/hub.py
@@ -119,7 +119,7 @@ class MirAIeHub:
             LOGGER.debug(f'reason: {response.reason}')
             LOGGER.debug(f'content_type: {response.content_type}')
             LOGGER.debug(f'text response: {await response.text()}')
-            raise Exception("Unable to fetch device details failed")
+            raise Exception("Unable to fetch device details")
             
 
     # Process the home details
@@ -146,24 +146,27 @@ class MirAIeHub:
                 )
                 self.topics_map[item.id] = topic
 
-        device_ids = ",".join(list(map(lambda device: device.id, devices)))
-        device_details = await self._get_device_details(device_ids)
+        if devices:
+            device_ids = ",".join(list(map(lambda device: device.id, devices)))
+            device_details = await self._get_device_details(device_ids)
 
-        for dd in device_details:
-            device = next(d for d in devices if d.id == dd["deviceId"])
+            for dd in device_details:
+                device = next(d for d in devices if d.id == dd["deviceId"])
 
-            details = DeviceDetails(
-                model_name=dd["modelName"],
-                mac_address=dd["macAddress"],
-                category=dd["category"],
-                brand=dd["brand"],
-                firmware_version=dd["firmwareVersion"],
-                serial_number=dd["serialNumber"],
-                model_number=dd["modelNumber"],
-                product_serial_number=dd["productSerialNumber"],
-            )
+                details = DeviceDetails(
+                    model_name=dd["modelName"],
+                    mac_address=dd["macAddress"],
+                    category=dd["category"],
+                    brand=dd["brand"],
+                    firmware_version=dd["firmwareVersion"],
+                    serial_number=dd["serialNumber"],
+                    model_number=dd["modelNumber"],
+                    product_serial_number=dd["productSerialNumber"],
+                )
 
-            device.set_details(details)
+                device.set_details(details)
+        else:
+            LOGGER.warning("No devices found on current account")
 
         self.home = Home(id=json_data["homeId"], devices=devices)
         return self.home


### PR DESCRIPTION
This PR implements a fix for the below error which occurs when trying to fetch device details API for an account with no devices

```
Traceback (most recent call last):
  File "/home/vikra/miraie-ac/.venv/lib/python3.12/site-packages/miraie_ac/hub.py", line 116, in _get_device_details
    return await response.json()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/vikra/miraie-ac/.venv/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 756, in json
    raise ContentTypeError(
aiohttp.client_exceptions.ContentTypeError: 404, message='Attempt to decode JSON with unexpected mimetype: text/html; charset=utf-8', url='https://app.miraie.in/simplifi/v1/deviceManagement/devices/deviceId/'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vikra/miraie-ac/src/main.py", line 108, in load_devices
    await hub._get_home_details()
  File "/home/vikra/miraie-ac/.venv/lib/python3.12/site-packages/miraie_ac/hub.py", line 181, in _get_home_details
    await self._process_home_details(resp[0])
  File "/home/vikra/miraie-ac/.venv/lib/python3.12/site-packages/miraie_ac/hub.py", line 154, in _process_home_details
    device_details = await self._get_device_details(device_ids)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vikra/miraie-ac/.venv/lib/python3.12/site-packages/miraie_ac/hub.py", line 124, in _get_device_details
    raise Exception("Unable to fetch device details failed")
Exception: Unable to fetch device details failed
```