### PR TITLE
fix: decode encoded rmtmp room temperature values

### DIFF
--- a/miraie_ac/device.py
+++ b/miraie_ac/device.py
@@ -1,7 +1,7 @@
 from typing import Callable
 from .broker import MirAIeBroker
 from .enums import PowerMode, FanMode, SwingMode, DisplayMode, HVACMode, PresetMode, ConvertiMode
-from .utils import toFloat
+from .utils import toFloat, toRoomTemp
 from .logger import LOGGER
 
 
@@ -148,7 +148,7 @@ class Device:
         status_obj = DeviceStatus(
             is_online=self.status.is_online,
             temperature=toFloat(status["actmp"]),
-            room_temperature=toFloat(status["rmtmp"]),
+            room_temperature=toRoomTemp(status["rmtmp"]),
             power_mode=PowerMode(status["ps"]),
             fan_mode=FanMode(status["acfs"]),
             v_swing_mode=SwingMode(status["acvs"]),

--- a/miraie_ac/hub.py
+++ b/miraie_ac/hub.py
@@ -9,7 +9,7 @@ from .home import Home
 from .device import Device, DeviceDetails, DeviceStatus
 from .enums import PowerMode, FanMode, SwingMode, DisplayMode, HVACMode, PresetMode, ConvertiMode, \
     ConsumptionPeriodType
-from .utils import is_valid_email, toFloat
+from .utils import is_valid_email, toFloat, toRoomTemp
 from .logger import LOGGER
 
 
@@ -215,7 +215,7 @@ class MirAIeHub:
                 status_obj = DeviceStatus(
                     is_online=status["onlineStatus"] == "true",
                     temperature=toFloat(status["actmp"]),
-                    room_temperature=toFloat(status["rmtmp"]),
+                    room_temperature=toRoomTemp(status["rmtmp"]),
                     power_mode=PowerMode(status["ps"]),
                     fan_mode=FanMode(status["acfs"]),
                     v_swing_mode=SwingMode(status["acvs"]),

--- a/miraie_ac/utils.py
+++ b/miraie_ac/utils.py
@@ -17,3 +17,23 @@ def toFloat(value: str) -> float:
         return float(value)
     except ValueError:
         return -1.0
+
+
+def toRoomTemp(value: str) -> float:
+    """Parse the room temperature (rmtmp) from a status payload.
+
+    Panasonic ACs report room temperatures in 0.5 degree steps, so a valid
+    fractional part is only 0.0 or 0.5. On some newer firmware, the rmtmp value
+    is encoded with unknown data before the actual room temperature,
+    e.g. 150.27 -> 27, 2.29 -> 29, 61.26 -> 26. So when the value carries a
+    fractional part that is neither zero nor 0.5, that decimal points to the
+    actual room temperature.
+    """
+    temp = toFloat(value)
+    if temp == -1.0:
+        return temp
+    fractional = temp - int(temp)
+    if fractional != 0 and fractional != 0.5:
+        # The decimal points to the actual room temperature.
+        return float(round(fractional * 100))
+    return temp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "miraie-ac"
-version = "1.1.1"
+version = "1.1.2"
 description = "MirAIe-AC API for Python"
 authors = ["Raj Kishore <40551183+rkzofficial@users.noreply.github.com>", "Ali Jafri <deCodeIt@users.noreply.github.com>", "Harith <82406332+gutpull@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Newer Panasonic firmware reports the room temperature (`rmtmp`) encoded with unknown data before the actual value, e.g. `150.27` -> actual temp `27`, `2.29` -> `29`, `61.26` -> `26` (see https://github.com/rkzofficial/ha-miraie-ac/issues/55).

Panasonic ACs report temperatures in 0.5 degree steps, so a valid fractional part is only `0.0` or `0.5`. When the payload carries any other non-zero decimal, that decimal points to the actual room temperature.

## Changes

- **`miraie_ac/utils.py`**: Added `toRoomTemp()` helper that decodes such encoded values:
  - Valid 0.5-step readings pass through untouched (`27.5`, `24.0`, `15.5`).
  - Encoded values are corrected (`150.27` -> `27`, `2.29` -> `29`, `61.26` -> `26`, `132.26` -> `26`, `132.31` -> `31`).
- **`miraie_ac/device.py`**: `status_handler()` (MQTT callback) now parses `rmtmp` via `toRoomTemp()`.
- **`miraie_ac/hub.py`**: `get_all_device_status()` (HTTP status fetch) now parses `rmtmp` via `toRoomTemp()`.
- **`pyproject.toml`**: Version bumped `1.1.1` -> `1.1.2`.

## Verification

Loaded `utils.py` standalone and confirmed all observed cases from the issue decode correctly while valid 0.5-step values are preserved.